### PR TITLE
fix: concurrent map writes error when multiple users connect

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -21,12 +22,13 @@ import (
 	"github.com/yanc0/musshis-heart/scenes"
 )
 
-const host = "0.0.0.0"
-const port = 2222
+var host = flag.String("host", "0.0.0.0", "host to listen on")
+var port = flag.Int("port", 2222, "port to listen on")
 
 func main() {
+	flag.Parse()
 	s, err := wish.NewServer(
-		wish.WithAddress(fmt.Sprintf("%s:%d", host, port)),
+		wish.WithAddress(fmt.Sprintf("%s:%d", *host, *port)),
 		wish.WithHostKeyPath(".ssh/term_info_ed25519"),
 		wish.WithMiddleware(
 			bm.Middleware(teaHandler),
@@ -39,7 +41,7 @@ func main() {
 
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
-	log.Printf("Starting SSH server on %s:%d", host, port)
+	log.Printf("Starting SSH server on %s:%d", *host, *port)
 	go func() {
 		if err = s.ListenAndServe(); err != nil {
 			log.Fatalln(err)

--- a/scenes/end.go
+++ b/scenes/end.go
@@ -60,9 +60,10 @@ func (scene End) Render() string {
 	button := lipgloss.JoinHorizontal(lipgloss.Top, okButton, quitButton)
 	ui := lipgloss.JoinVertical(lipgloss.Center, message, button)
 
+	bxStyle := boxStyle.Copy().BorderForeground(lipgloss.Color("#c2a908"))
 	dialog := lipgloss.Place(scene.width, scene.height,
 		lipgloss.Center, lipgloss.Center,
-		boxStyle.BorderForeground(lipgloss.Color("#874BFD")).Render(ui),
+		bxStyle.Render(ui),
 		lipgloss.WithWhitespaceChars("°"),
 		lipgloss.WithWhitespaceForeground(subtleColor),
 	)

--- a/scenes/game.go
+++ b/scenes/game.go
@@ -94,9 +94,10 @@ func (scene Game) Render() string {
 
 	tui := lipgloss.JoinVertical(lipgloss.Center, lifetimeBox, warningMessageBox, musshiBox, heartBox)
 
+	bxStyle := boxStyle.Copy().BorderForeground(lipgloss.Color(heartColor))
 	doc.WriteString(lipgloss.Place(scene.width, 0,
 		lipgloss.Center, lipgloss.Center,
-		boxStyle.BorderForeground(lipgloss.Color(heartColor)).Render(tui),
+		bxStyle.Render(tui),
 		lipgloss.WithWhitespaceChars(" "),
 	))
 

--- a/scenes/start.go
+++ b/scenes/start.go
@@ -36,9 +36,10 @@ func (scene Start) Render() string {
 	button := lipgloss.JoinHorizontal(lipgloss.Top, okButton, quitButton)
 	ui := lipgloss.JoinVertical(lipgloss.Center, message, button)
 
+	bxStyle := boxStyle.Copy().BorderForeground(lipgloss.Color("#c2a908"))
 	dialog := lipgloss.Place(scene.width, scene.height,
 		lipgloss.Center, lipgloss.Center,
-		boxStyle.BorderForeground(lipgloss.Color("#c2a908")).Render(ui),
+		bxStyle.Render(ui),
 		lipgloss.WithWhitespaceChars("°"),
 		lipgloss.WithWhitespaceForeground(subtleColor),
 	)


### PR DESCRIPTION
Fixes a race issue when multiple users connect, the game uses a shared lipgloss style which triggers a `fatal error: concurrent map writes` error. 

This also makes `host` and `port` flags so that they can be passed as arguments instead of hard-coded values. 
```
musshis-heart -port 1234 -host 0.0.0.0
```